### PR TITLE
Fix low-priority issues: query efficiency, write safety, collision bound, dirty?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.17] - 2026-02-28
+
+### Fixed
+
+- `Relation#first` no longer allocates an intermediate Relation via `limit(1)`.
+  When no ordering is required, it uses the `load_matching` fast path directly.
+  When ordering is required, it calls `to_a.first` without the extra allocation.
+- `Relation#count` now skips sorting and offset/limit when no ordering is present,
+  counting filtered matches directly. For unfiltered queries, it counts glob
+  matches without parsing file contents.
+- `Repository#write_atomic` captures the temp file path before the `begin` block,
+  preventing potential issues if the `Tempfile` object state changes after a
+  failed `mv`.
+- `Repository#resolve_collision` now raises `FMRepo::Error` after 10,000 attempts
+  instead of looping indefinitely.
+
+### Added
+
+- `Record#dirty?` returns whether the record has unsaved changes. Complements the
+  existing `persisted?` and `new_record?` methods.
+
 ## [0.2.16] - 2026-02-28
 
 ### Added
@@ -214,6 +235,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite (56 tests)
 - Documentation and examples
 
+[0.2.17]: https://github.com/calef/fmrepo/releases/tag/v0.2.17
 [0.2.16]: https://github.com/calef/fmrepo/releases/tag/v0.2.16
 [0.2.15]: https://github.com/calef/fmrepo/releases/tag/v0.2.15
 [0.2.14]: https://github.com/calef/fmrepo/releases/tag/v0.2.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fmrepo (0.2.16)
+    fmrepo (0.2.17)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Post.published.recent.to_a
 - `id` - Get repo-relative path
 - `persisted?` - Check if saved
 - `new_record?` - Check if new
+- `dirty?` - Check if record has unsaved changes
 
 ### Predicates
 

--- a/lib/fmrepo/record.rb
+++ b/lib/fmrepo/record.rb
@@ -444,6 +444,10 @@ module FMRepo
       !@new_record
     end
 
+    def dirty?
+      @dirty
+    end
+
     def save!
       ensure_repo!
       ensure_path!

--- a/lib/fmrepo/relation.rb
+++ b/lib/fmrepo/relation.rb
@@ -73,8 +73,21 @@ module FMRepo
       apply_offset_limit(docs)
     end
 
-    def first = limit(1).to_a.first
-    def count = to_a.length
+    def first
+      if @orders.empty?
+        load_matching(max: @offset_n + 1).drop(@offset_n).first
+      else
+        to_a.first
+      end
+    end
+
+    def count
+      if @orders.empty? && @limit_n.nil?
+        load_matching_count
+      else
+        to_a.length
+      end
+    end
 
     # NOTE: front_matter_only: is only supported for direct lookups via find.
     # Bulk iteration via where/all always loads full records including body.
@@ -91,6 +104,22 @@ module FMRepo
     end
 
     private
+
+    def load_matching_count
+      cfg = @model.config
+      raise ArgumentError, "#{@model.name} has no scope glob" unless cfg.glob
+
+      paths = @repo.glob(cfg.glob)
+      paths = apply_excludes(paths, cfg.exclude)
+      return paths.size if @filters.empty?
+
+      count = 0
+      paths.each do |p|
+        rec = @model.load_from_path(repo: @repo, abs_path: p)
+        count += 1 if @filters.all? { |crit| matches_criteria?(rec, crit) }
+      end
+      count
+    end
 
     def load_matching(max:)
       cfg = @model.config

--- a/lib/fmrepo/relation.rb
+++ b/lib/fmrepo/relation.rb
@@ -82,7 +82,7 @@ module FMRepo
     end
 
     def count
-      if @orders.empty? && @limit_n.nil?
+      if @orders.empty? && @limit_n.nil? && @offset_n.zero?
         load_matching_count
       else
         to_a.length

--- a/lib/fmrepo/repository.rb
+++ b/lib/fmrepo/repository.rb
@@ -25,13 +25,14 @@ module FMRepo
 
       require 'tempfile'
       tmp = Tempfile.create([abs.basename.to_s, '.tmp'], dir)
+      tmp_path = tmp.path
       begin
         tmp.write(content)
         tmp.close
-        FileUtils.mv(tmp.path, abs.to_s)
+        FileUtils.mv(tmp_path, abs.to_s)
       ensure
         tmp.close unless tmp.closed?
-        tmp.unlink if tmp && File.exist?(tmp.path)
+        File.delete(tmp_path) if File.exist?(tmp_path)
       end
     end
 
@@ -40,6 +41,8 @@ module FMRepo
       FileUtils.rm_f(Pathname.new(abs_path).to_s)
     end
 
+    MAX_COLLISION_ATTEMPTS = 10_000
+
     def resolve_collision(rel_path)
       rel = Pathname.new(rel_path.to_s)
       abs = @root.join(rel)
@@ -47,13 +50,12 @@ module FMRepo
 
       base = rel.sub_ext('')
       ext = rel.extname
-      i = 2
-      loop do
+      2.upto(MAX_COLLISION_ATTEMPTS) do |i|
         candidate = Pathname.new("#{base}-#{i}#{ext}")
         return candidate unless @root.join(candidate).exist?
-
-        i += 1
       end
+
+      raise Error, "Could not resolve filename collision for #{rel} after #{MAX_COLLISION_ATTEMPTS} attempts"
     end
 
     def abs(rel_path)

--- a/lib/fmrepo/version.rb
+++ b/lib/fmrepo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FMRepo
-  VERSION = '0.2.16'
+  VERSION = '0.2.17'
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -373,6 +373,39 @@ class RecordTest < Minitest::Test
     assert_includes content, 'rails'
   end
 
+  def test_dirty_returns_true_for_new_record
+    rec = FMRepo::Record.new({ 'title' => 'Test' })
+    assert rec.dirty?
+  end
+
+  def test_dirty_returns_false_after_save
+    path = File.join(@tmpdir, 'test.md')
+    rec = FMRepo::Record.new({ 'title' => 'Test' }, body: '', path: path, repo: @repo)
+    rec.save!
+    refute rec.dirty?
+  end
+
+  def test_dirty_returns_true_after_modification
+    path = File.join(@tmpdir, 'test.md')
+    rec = FMRepo::Record.new({ 'title' => 'Test' }, body: '', path: path, repo: @repo)
+    rec.save!
+    refute rec.dirty?
+
+    rec['title'] = 'Updated'
+    assert rec.dirty?
+  end
+
+  def test_dirty_returns_false_after_reload
+    path = File.join(@tmpdir, 'test.md')
+    rec = FMRepo::Record.new({ 'title' => 'Test' }, body: '', path: path, repo: @repo)
+    rec.save!
+    rec['title'] = 'Modified'
+    assert rec.dirty?
+
+    rec.reload
+    refute rec.dirty?
+  end
+
   def test_load_from_path_front_matter_only_skips_body
     record = FMRepo::Record.new({ 'title' => 'Test', 'count' => 42 }, body: 'Big XML body here')
     record.instance_variable_set(:@repo, @repo)

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -121,6 +121,10 @@ class RepositoryTest < Minitest::Test
     assert_equal 'subdir/file.md', rel.to_s
   end
 
+  def test_resolve_collision_has_max_attempts_constant
+    assert_equal 10_000, FMRepo::Repository::MAX_COLLISION_ATTEMPTS
+  end
+
   def test_assert_within_root_allows_paths_in_root
     path = File.join(@tmpdir, 'file.md')
     assert_nil @repo.assert_within_root!(path)


### PR DESCRIPTION
## Summary

- **`Relation#first` efficiency**: No longer allocates an intermediate Relation via `limit(1)`. Uses the `load_matching` fast path directly when no ordering is needed, or `to_a.first` when ordering is present.
- **`Relation#count` efficiency**: Skips sorting and offset/limit overhead. For unfiltered queries without ordering, counts glob matches without parsing file contents. For filtered queries, counts matches directly without building a full sorted array.
- **`write_atomic` robustness**: Captures `tmp.path` into a local variable before the `begin` block, preventing potential issues if the Tempfile object state changes after a failed `mv`.
- **`resolve_collision` bound**: Raises `FMRepo::Error` after 10,000 attempts instead of looping indefinitely.
- **`Record#dirty?`**: New public method exposing the existing `@dirty` tracking. Complements `persisted?` and `new_record?`.
- **Version bump**: 0.2.16 → 0.2.17

## Test plan

- [x] Full test suite passes (133 tests, 286 assertions, 0 failures)
- [x] `dirty?` returns true for new records, false after save, true after modification, false after reload
- [x] `MAX_COLLISION_ATTEMPTS` constant is set to 10,000
- [x] Existing `first`, `count`, `find_by`, collision resolution tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)